### PR TITLE
Update README to remove job targeting details

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <p align="center">
   <strong>I build systems that reason — autonomous agents, RAG pipelines, and production AI.</strong><br/>
-  <sub>Mumbai · CS Graduate, Mumbai University · Targeting Germany & Abu Dhabi</sub>
+  <sub>Mumbai · CS Graduate, Mumbai University</sub>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Removed targeting information for job roles in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the profile header subtitle to remove the “Targeting Germany & Abu Dhabi” wording.
  * The subtitle now displays only “Mumbai · CS Graduate, Mumbai University.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->